### PR TITLE
Support managing a GitHub App's JWT in GitHubAPI

### DIFF
--- a/docs/abc.rst
+++ b/docs/abc.rst
@@ -24,7 +24,7 @@ does not require an update to the library, allowing one to use
 experimental APIs without issue.
 
 
-.. class:: GitHubAPI(requester, *, oauth_token=None, cache=None, base_url=sansio.DOMAIN)
+.. class:: GitHubAPI(requester, *, oauth_token=None, app_id=None, private_key=None, cache=None, base_url=sansio.DOMAIN)
 
     Provide an :py:term:`abstract base class` which abstracts out the
     HTTP library being used to send requests to GitHub. The class is
@@ -80,6 +80,21 @@ experimental APIs without issue.
     .. attribute:: oauth_token
 
         The provided OAuth token (if any).
+
+        An OAuth token cannot be set with the *app_id* and *private_key*.
+    
+    .. attribute:: app_id
+
+        The provided GitHub App ID (if any) to authenticate as a GitHub App.
+        Must be used with *private_key*.
+    
+    .. attribute:: private_key
+
+        The provided GitHub App private key (if any) to authenticate as a
+        GitHub App. Must be used with *app_id*.
+
+        To authenticate as an installation of a GitHub App, use the
+        *oauth_token* argument instead.
 
     .. attribute:: base_url
 

--- a/docs/abc.rst
+++ b/docs/abc.rst
@@ -70,6 +70,9 @@ experimental APIs without issue.
 
     .. versionchanged:: 4.0
         Introduced the *base_url* argument to the constructor.
+    
+    .. versionchanged:: 5.4.0
+        Introduced the *app_id* and *private_key* arguments to the constructor.
 
     .. attribute:: requester
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-Unreleased
+5.4.0.dev1
 ----------
 
 - The `gidgethub.abc.GitHubApi` optionally accepts ``app_id`` and ``private_key`` arguments to automatically authenticate requests as a GitHub App.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- The `gidgethub.abc.GitHubApi` optionally accepts ``app_id`` and ``private_key`` arguments to automatically authenticate requests as a GitHub App.
+
 5.3.0
 -----
 

--- a/docs/routing.rst
+++ b/docs/routing.rst
@@ -7,7 +7,7 @@
 
 When a single web service is used to perform multiple actions based on
 a single
-`webhook event <https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/about-webhooks#events>`_, it
+`webhook event <https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads>`_, it
 is easier to do those multiple steps in some sort of routing mechanism
 to make sure the right objects are called is provided. This module is
 meant to provide such a router for :class:`gidgethub.sansio.Event`

--- a/docs/sansio.rst
+++ b/docs/sansio.rst
@@ -51,7 +51,7 @@ without requiring the use of the :class:`Event` class.
    .. attribute:: event
 
       The string representation of the
-      `triggering event <https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/about-webhooks#events>`_.
+      `triggering event <https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads>`_.
 
 
    .. attribute:: delivery_id

--- a/gidgethub/abc.py
+++ b/gidgethub/abc.py
@@ -47,11 +47,7 @@ class GitHubAPI(abc.ABC):
     ) -> None:
         if all(_ is not None for _ in (oauth_token, app_id, private_key)):
             raise ValueError(
-                "Cannot pass oauth_token at the same time as app_id and "
-                "private_key. Use oauth token if authenticating as an OAuth "
-                "App, with a personal access token, or as an installation of a "
-                "GitHub App. Othewise, use app_id and private_key to "
-                "authenticate as a GitHub App with a JWT."
+                "Cannot pass oauth_token if app_id and private_key are also passed."
             )
 
         self.requester = requester

--- a/gidgethub/abc.py
+++ b/gidgethub/abc.py
@@ -4,8 +4,11 @@ import http
 import json
 from typing import Any, AsyncGenerator, Dict, Mapping, MutableMapping, Optional, Tuple
 from typing import Optional as Opt
+import jwt
 
 from uritemplate import variable
+
+from gidgethub.apps import get_jwt
 
 from . import (
     BadGraphQLRequest,
@@ -37,11 +40,25 @@ class GitHubAPI(abc.ABC):
         requester: str,
         *,
         oauth_token: Opt[str] = None,
+        app_id: Opt[str] = None,
+        private_key: Opt[str] = None,
         cache: Opt[CACHE_TYPE] = None,
         base_url: str = sansio.DOMAIN,
     ) -> None:
+        if all(_ is not None for _ in (oauth_token, app_id, private_key)):
+            raise ValueError(
+                "Cannot pass oauth_token at the same time as app_id and "
+                "private_key. Use oauth token if authenticating as an OAuth "
+                "App, with a personal access token, or as an installation of a "
+                "GitHub App. Othewise, use app_id and private_key to "
+                "authenticate as a GitHub App with a JWT."
+            )
+
         self.requester = requester
         self.oauth_token = oauth_token
+        self.app_id = app_id
+        self.private_key = private_key
+        self._jwt: Opt[str] = None  # cached JWT from app_id and private_key
         self._cache = cache
         self.rate_limit: Opt[sansio.RateLimit] = None
         self.base_url = base_url
@@ -80,10 +97,17 @@ class GitHubAPI(abc.ABC):
             request_headers = sansio.create_headers(
                 self.requester, accept=accept, oauth_token=oauth_token
             )
-        else:
-            # fallback to using oauth_token
+        elif self.oauth_token is not None:
+            # fallback to using default oauth_token
             request_headers = sansio.create_headers(
                 self.requester, accept=accept, oauth_token=self.oauth_token
+            )
+        else:
+            # fallback to using GitHub App JWT (it may be None, in which case
+            # no authentication will be set.)
+            app_jwt = self.jwt
+            request_headers = sansio.create_headers(
+                self.requester, accept=accept, jwt=app_jwt
             )
         if extra_headers is not None:
             request_headers.update(extra_headers)
@@ -125,6 +149,28 @@ class GitHubAPI(abc.ABC):
                 last_modified = response[1].get("last-modified")
                 self._cache[filled_url] = etag, last_modified, data, more
         return data, more, response[0]
+
+    @property
+    def jwt(self) -> Opt[str]:
+        """A JWT for authenticating as a GitHub App (available if ``app_id``
+        and ``private_key`` are set).
+        """
+        if self.app_id is None or self.private_key is None:
+            return None
+
+        # Check if an existing JWT is still valid.
+        if self._jwt is not None:
+            try:
+                jwt.decode(
+                    self._jwt, options={"verify_signature": False, "verify_exp": True}
+                )
+                return self._jwt
+            except jwt.ExpiredSignatureError:
+                self._jwt = None
+
+        self._jwt = get_jwt(app_id=self.app_id, private_key=self.private_key)
+
+        return self._jwt
 
     async def getitem(
         self,

--- a/gidgethub/apps.py
+++ b/gidgethub/apps.py
@@ -1,10 +1,14 @@
 """Support for GitHub Actions."""
-from typing import cast, Any, Dict
+
+from __future__ import annotations
+
+from typing import cast, Any, Dict, TYPE_CHECKING
 
 import time
 import jwt
 
-from gidgethub.abc import GitHubAPI
+if TYPE_CHECKING:
+    from gidgethub.abc import GitHubAPI
 
 
 def get_jwt(*, app_id: str, private_key: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,6 @@ branch = true
 
 [tool.coverage.report]
 fail_under = 100
+exclude_lines = [
+    "if TYPE_CHECKING:"
+]

--- a/tests/test_sansio.py
+++ b/tests/test_sansio.py
@@ -493,7 +493,6 @@ class TestDecipherResponse:
         assert rate_limit.remaining == 48
         assert data[0]["url"] == "https://api.github.com/repos/django/django/pulls/6395"
 
-    @pytest.mark.asyncio
     def test_next_with_search_api(self):
         status_code = 200
         headers, body = sample("search_issues_page_1", status_code)


### PR DESCRIPTION
This PR makes it possible for a GitHubAPI instance to automatically authenticate requests as a GitHub App (as opposed to an *app installation*). By setting the `app_id` and `private_key` arguments, GitHubAPI will automatically generate and use a JWT to authenticate as the app. Passing an `oauth_token` or `jwt` argument directly to one of the request methods overrides the managed JWT as the authentication method.

The JWT is available from the `GitHubApi.jwt` property. The computed JWT is cached, but is regenerated if necessary.

Let me know what you think about this caching functionality. The `verify_exp` option on `jwt.decode()` is what I landed on for testing an existing JWT's validity. I'm not sure how much more efficient this is than treating JWT's as entirely ephemeral, but seems to work well.

I also did some other clean-up activities to get the tests/linters to work. I've put those in separate commits.

Closes #199 
