### PR TITLE
Fix rate-limit bug

### DIFF
--- a/gidgethub/sansio.py
+++ b/gidgethub/sansio.py
@@ -339,7 +339,7 @@ def decipher_response(
             exc_type = BadRequest
             if status_code == 403:
                 rate_limit = RateLimit.from_http(headers)
-                if rate_limit and not rate_limit.remaining:
+                if rate_limit != None and not rate_limit.remaining:
                     raise RateLimitExceeded(rate_limit, message)
             elif status_code == 422:
                 try:


### PR DESCRIPTION
In handling error-responses from the server the code checks if it's possible to create a rate limit object from the headers through `RateLimit.from_http(headers)`. This function returns an object if rate limit info was found, and None otherwise. 

The next line of code wants to check if this value was not none, but does not do so epxlicitly: `if rate_limit`. This causes python to evaluate it as a boolean and call `RateLimit.__bool__`. This will only return `True` if `self.remaining > 0`, which would not be the case if the rate-limit was indeed exceeded.

The proposed fix simply explicitly checks if the returned `RateLimit` object is not `None`.
