### PR TITLE
Set a maximum version of flit_core for build requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core"]
+requires = ["flit_core <4"]
 build-backend = "flit_core.buildapi"
 
 [tool.flit.metadata]


### PR DESCRIPTION
The plan for Flit 4 is to drop support for the `[tool.flit.metadata]` project description in favour of the [`[project]` table](https://flit.pypa.io/en/stable/pyproject_toml.html#new-style-metadata), which is now standardised across different tools. 

More generally, I advise packages to always restrict the dependency to exclude the next major version of flit_core, so that I can make breaking changes. You can see the version ranges recommendations here: https://flit.pypa.io/en/stable/pyproject_toml.html#build-system-section