### PR TITLE
Add expiration parameter to apps.get_jwt

### DIFF
--- a/docs/apps.rst
+++ b/docs/apps.rst
@@ -43,10 +43,10 @@ Example on how you would obtain the access token for authenticating as a GitHub 
     `Authenticating as an installation <https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/about-authentication-with-a-github-app#authentication-as-an-app-installation>`_ API endpoint.
 
 
-.. function:: get_jwt(*, app_id, private_key)
+.. function:: get_jwt(*, app_id, private_key, expiration = 10 * 60)
 
    Construct the JWT (JSON Web Token), that can be used to access endpoints
-   that require it.
+   that require it. Default expiration period is 10 minutes.
 
    Example::
 
@@ -58,7 +58,10 @@ Example on how you would obtain the access token for authenticating as a GitHub 
        -----END RSA PRIVATE KEY-----
        """
 
-       token = get_jwt(app_id=123, private_key=private_key)
+       # Generate a token that expires 30 minutes from now
+       token = get_jwt(
+           app_id=123, private_key=private_key, expiration = 30 * 60
+       )
        data = gh.getitem(
            "/app/installations",
            jwt=token,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 Unreleased
 ----------
 
+- :meth:`gidgethub.apps.get_jwt` now accepts an ``expiration`` parameter to
+  configure JWT token expiration time
+  (`PR #215 <https://github.com/gidgethub/gidgethub/pull/215>`_)
+
 - Add support for Python 3.12-3.13 and drop EOL Python 3.7
   (`PR #209 <https://github.com/brettcannon/gidgethub/pull/209>`_)
 

--- a/gidgethub/apps.py
+++ b/gidgethub/apps.py
@@ -8,10 +8,10 @@ import jwt
 from gidgethub.abc import GitHubAPI
 
 
-def get_jwt(*, app_id: str, private_key: str) -> str:
+def get_jwt(*, app_id: str, private_key: str, expiration: int = 10 * 60) -> str:
     """Construct the JWT (JSON Web Token), used for GitHub App authentication."""
     time_int = int(time.time())
-    payload = {"iat": time_int, "exp": time_int + (10 * 60), "iss": app_id}
+    payload = {"iat": time_int, "exp": time_int + expiration, "iss": app_id}
     bearer_token = jwt.encode(payload, private_key, algorithm="RS256")
 
     return bearer_token

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -33,6 +33,30 @@ class TestGitHubAppUtils:
 
         assert result == jwt.encode(expected_payload, private_key, algorithm="RS256")
 
+    @mock.patch("time.time")
+    def test_get_jwt_with_custom_expiry(self, time_mock):
+        app_id = 12345
+
+        time_mock.return_value = 1587069751.5588422
+
+        # test file copied from https://github.com/jpadilla/pyjwt/blob/master/tests/keys/testkey_rsa
+        private_key = (
+            importlib_resources.files(rsa_key_samples) / "test_rsa_key"
+        ).read_bytes()
+
+        # Custom expiration
+        expiration = 30 * 60
+        result = apps.get_jwt(
+            app_id=app_id, private_key=private_key, expiration=expiration
+        )
+        expected_payload = {
+            "iat": 1587069751,
+            "exp": 1587069751 + expiration,
+            "iss": app_id,
+        }
+
+        assert result == jwt.encode(expected_payload, private_key, algorithm="RS256")
+
     @pytest.mark.asyncio
     async def test_get_installation_access_token(self):
         gh = MockGitHubAPI()


### PR DESCRIPTION
This PR is backwards compatible, and simply makes the expiration time of the token generated from `get_jwt` configurable.