### PR TITLE
refactor(build): migrate from tool.flit.metadata to project table

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,19 +2,17 @@
 requires = ["flit_core <4"]
 build-backend = "flit_core.buildapi"
 
-[tool.flit.metadata]
-module = "gidgethub"
-author = "Brett Cannon"
-author-email = "brett@python.org"
-requires = [
-    "uritemplate>=3.0.1",
-    "PyJWT[crypto]>=2.4.0"
+[project]
+name = "gidgethub"
+authors = [
+    {name = "Brett Cannon", email = "brett@python.org"},
 ]
-requires-python = ">=3.8"
-license = "Apache"
-keywords = "github sans-io async"
 description-file = "README.rst"
-classifiers = ["Intended Audience :: Developers",
+license = {text = "Apache"}
+requires-python = ">=3.8"
+keywords = ["github", "sans-io", "async"]
+classifiers = [
+    "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 3 :: Only",
@@ -25,21 +23,39 @@ classifiers = ["Intended Audience :: Developers",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
+dependencies = [
+    "uritemplate>=3.0.1",
+    "PyJWT[crypto]>=2.4.0",
+]
 
-[tool.flit.metadata.requires-extra]
-test = ["importlib-resources", "pytest>=5.4.1", "pytest-asyncio", "pytest-tornasync"]
-doc = ["sphinx>=4.0.0", "sphinx-rtd-theme>=0.5.2"]
-# The 'dev' target should contain all dependencies listed in any extras coming
-# after it to make sure that the test suite will run successfully.
-dev = ["aiohttp", "black", "coverage[toml]>=5.0.3", "httpx", "mypy", "pytest-cov",
-       "pytest-xdist", "tornado"]
+[project.urls]
+Documentation = "https://gidgethub.readthedocs.io"
+Repository = "https://github.com/brettcannon/gidgethub"
+
+[project.optional-dependencies]
+test = [
+    "importlib-resources",
+    "pytest>=5.4.1",
+    "pytest-asyncio",
+    "pytest-tornasync",
+]
+doc = [
+    "sphinx>=4.0.0",
+    "sphinx-rtd-theme>=0.5.2",
+]
+dev = [
+    "aiohttp",
+    "black",
+    "coverage[toml]>=5.0.3",
+    "httpx",
+    "mypy",
+    "pytest-cov",
+    "pytest-xdist",
+    "tornado",
+]
 aiohttp = ["aiohttp"]
 tornado = ["tornado"]
 httpx = ["httpx>=0.16.1"]
-
-[tool.flit.metadata.urls]
-Documentation = "https://gidgethub.readthedocs.io"
-Repository = "https://github.com/brettcannon/gidgethub"
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
Closes #210 
Update pyproject.toml to use modern PEP 621 project metadata format instead of tool-specific flit tables.