### PR TITLE
Fix incorrect rate_limit boolean check in decipher_response

### DIFF
--- a/gidgethub/sansio.py
+++ b/gidgethub/sansio.py
@@ -339,7 +339,7 @@ def decipher_response(
             exc_type = BadRequest
             if status_code == 403:
                 rate_limit = RateLimit.from_http(headers)
-                if rate_limit and not rate_limit.remaining:
+                if rate_limit is not None and not rate_limit.remaining:
                     raise RateLimitExceeded(rate_limit, message, headers=headers)
             elif status_code == 422:
                 try:


### PR DESCRIPTION
## Summary

The original check  fails when  because  returns False when remaining is 0. This causes the code to miss rate-limit-exceeded cases.

## Fix

Changed to  which properly handles:
1. The None case from  when headers lack rate limit info
2. The remaining==0 case where the rate limit is exhausted

## Testing

- All 61 existing tests pass
- Verified the new check correctly evaluates to True when remaining==0, while the old check incorrectly evaluated to False

Fixes gidgethub/gidgethub#231